### PR TITLE
Add sample app showing Attachments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,14 @@ path = "src/bin/simple_querybuilder.rs"
 name = "simple-dql"
 path = "src/bin/simple_dql.rs"
 
+[[bin]]
+name = "simple-attachment"
+path = "src/bin/simple_attachment.rs"
+
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
-tokio = { version = "1" }
+tokio = { version = "1", features = ["sync"] }
 serde_json = "1"
 
 # Ditto

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Now you can build and run the available sample apps. Be sure to check the
 
 ### Simple Querybuilder
 
+This sample shows how to use Ditto's "Query Builder" API to
+create and subscribe to documents:
+
 ```
 cargo run --bin=simple_querybuilder -- --collection="cars"
 # ...
@@ -54,10 +57,24 @@ Inserted document with id=6659efed00288113001bb5a9
 
 ### Simple DQL
 
+This sample shows how to use Ditto's new "Ditto Query Lanuage" (or DQL)
+to insert and query for documents:
+
 ```
 cargo run --bin=simple_dql -- create-car --make="ford" --year="2016" --color="blue"
 
 cargo run --bin=simple_dql -- query-cars --color="blue"
+```
+
+### Simple Attachments
+
+This sample shows how to upload and download large files using Ditto's
+Attachments API:
+
+```
+cargo run --bin=simple_attachments -- upload-photo --path=$HOME/Downloads/photo.png
+
+cargo run --bin=simple_attachments -- download-photo --name=photo.png
 ```
 
 [0]: https://ditto.live

--- a/src/bin/simple_attachment.rs
+++ b/src/bin/simple_attachment.rs
@@ -1,0 +1,175 @@
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use dittolive_ditto::{identity::*, prelude::*};
+use std::{
+    self,
+    collections::HashMap,
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+};
+
+/// A sample app to demo Ditto's Rust SDK, see long '--help' for examples
+///
+/// This will log into your Ditto app via the AppID and Token
+/// you provide. These can be found at <https://portal.ditto.live>.
+/// See the README to see how to set up ENVs for the AppID and Token.
+///
+/// Use the `upload-photo` and `download-photo` commands to explore using
+/// Ditto attachments
+///
+/// Example: upload a photo
+///
+/// > simple_attachment upload-photo --path=$HOME/Downloads/photo.png
+///
+/// Example: download a photo by name
+///
+/// > simple_attachment download-photo --name=photo.png
+#[derive(Debug, Parser)]
+struct Cli {
+    #[clap(flatten)]
+    args: Args,
+
+    #[clap(subcommand)]
+    cmd: Cmd,
+}
+
+/// Args needed for any command,
+#[derive(Debug, Parser)]
+struct Args {
+    /// The Ditto App ID to sync with (found at portal.ditto.live)
+    #[clap(long, env = "APP_ID")]
+    app_id: String,
+
+    /// The Playground token used to authenticate (found at portal.ditto.live)
+    #[clap(long, env = "PLAYGROUND_TOKEN")]
+    playground_token: String,
+}
+
+#[derive(Debug, Subcommand)]
+enum Cmd {
+    UploadPhoto {
+        /// Path to a file to upload as an attachment
+        #[clap(long)]
+        path: PathBuf,
+    },
+    DownloadPhoto {
+        /// Name of the attachment file to download
+        #[clap(long)]
+        name: String,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    dotenv::dotenv().ok();
+    let cli = Cli::parse();
+
+    // Initialize Ditto SDK client
+    let args = &cli.args;
+    let app_id = AppId::from_str(&args.app_id)?;
+    let ditto = Ditto::builder()
+        .with_root(Arc::new(PersistentRoot::from_current_exe()?))
+        .with_minimum_log_level(LogLevel::Debug)
+        .with_identity(move |ditto_root| {
+            let shared_token = args.playground_token.clone();
+            let enable_cloud_sync = true;
+            let custom_auth_url = None;
+            OnlinePlayground::new(
+                ditto_root,
+                app_id,
+                shared_token,
+                enable_cloud_sync,
+                custom_auth_url,
+            )
+        })?
+        .build()?;
+
+    // Begin sync, then open the Ditto Store so we can insert or query documents
+    ditto.start_sync()?;
+    let store = ditto.store();
+
+    match cli.cmd {
+        Cmd::UploadPhoto { path } => {
+            upload_photo(store, &path).await?;
+        }
+        Cmd::DownloadPhoto { name } => {
+            download_photo(store, &name).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn upload_photo(store: &Store, path: &Path) -> Result<()> {
+    let photo_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("photo");
+
+    let photo_attachment = store.new_attachment(path, HashMap::default()).await?;
+    let _result = store
+        .execute(
+            "INSERT INTO COLLECTION photos (photo_attachment ATTACHMENT) DOCUMENTS (:photo_doc)",
+            Some(
+                serde_json::json!({
+                    "photo_doc": {
+                        "photo_name": photo_name,
+                        "photo_attachment": photo_attachment
+                    }
+                })
+                .into(),
+            ),
+        )
+        .await?;
+
+    println!("Uploaded photo with name '{photo_name}'");
+    Ok(())
+}
+
+async fn download_photo(store: &Store, name: &str) -> Result<()> {
+    let result = store
+        .execute(
+            "SELECT * FROM COLLECTION photos (photo_attachment ATTACHMENT)",
+            Some(
+                serde_json::json!({
+                    "photo_name": name
+                })
+                .into(),
+            ),
+        )
+        .await?;
+
+    let result_item = result
+        .get_item(0)
+        .context("result set contained no items")?
+        .value();
+
+    let photo_attachment = result_item
+        .get("photo_attachment")
+        .context("failed to find photo_attachment")?;
+
+    let photo_attachment_token = photo_attachment
+        .as_object()
+        .context("failed to get attachment token")?;
+
+    let photo_id = photo_attachment
+        .get("id")
+        .context("failed to get ID of attachment")?
+        .clone(); // Cloned to move into closure below
+
+    let _fetcher = store.fetch_attachment(photo_attachment_token, move |event| {
+        use DittoAttachmentFetchEvent::*;
+        match event {
+            Progress {
+                downloaded_bytes,
+                total_bytes,
+            } => {
+                println!("Fetcher progress for attachment {photo_id:?}: {downloaded_bytes}b/{total_bytes}b");
+            }
+            Completed { attachment } => {
+                println!("Successfully downloaded attachment {photo_id:?} to path {}", attachment.path().display());
+            }
+            Deleted => unreachable!("attachment should not get deleted while fetching"),
+        }
+    })?;
+
+    Ok(())
+}


### PR DESCRIPTION
Followup to #2 (need to merge that first) which adds another sample app, this time showcasing the Attachments API.

- Sample app includes `upload-photo` and `download-photo` subcommands
- Upload a photo by path, download by name
- Update README to show how to invoke example