### PR TITLE
Tweak DQL sample to match dittolive_ditto crate docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,7 @@ dependencies = [
  "dittolive-ditto",
  "dittolive-ditto-sys",
  "dotenv",
+ "serde",
  "serde_json",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/bin/simple_attachment.rs"
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
 tokio = { version = "1", features = ["sync"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 # Ditto


### PR DESCRIPTION
I updated the `dittolive_ditto` crate docs with some similar examples and the second time through writing DQL examples, I liked the way the flow was set up better, so I'm tweaking them here to match. This will also serve as a way to test that the crate docs work as expected, since they can only be build-checked and not run-checked (because of keys).